### PR TITLE
Comment on Articles API

### DIFF
--- a/prisma/migrations/20250725043515_add_comment_timestamps/migration.sql
+++ b/prisma/migrations/20250725043515_add_comment_timestamps/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Added the required column `updatedAt` to the `Comment` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Comment" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,4 +37,6 @@ model Comment {
   articleId Int
   author    User    @relation(fields: [authorId], references: [id])
   authorId  Int
+  createdAt DateTime @default(now())       
+  updatedAt DateTime @updatedAt
 }

--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -63,30 +63,5 @@ export class ArticlesController {
     return this.articlesService.deleteArticle(slug, req.user.sub);
   }
 
-  @Post(':slug/comments')
-  @UseGuards(AuthGuard('jwt'))
-  async createComment(
-    @Param('slug') slug: string,
-    @Body('comment') createCommentDto: CreateCommentDto,
-    @GetUser() user: JwtPayload,
-  ): Promise<CommentResponse> {
-    return this.articlesService.createComment(slug, user.sub, createCommentDto);
-  }
 
-  @Get(':slug/comments')
-  async getComments(
-    @Param('slug') slug: string,
-  ): Promise<CommentsResponse> {
-    return this.articlesService.getComments(slug);
-  }
-
-  @Delete(':slug/comments/:id')
-  @UseGuards(AuthGuard('jwt'))
-  async deleteComment(
-    @Param('slug') slug: string,
-    @Param('id') id: string,
-    @GetUser() user: JwtPayload,
-  ): Promise<void> {
-    return this.articlesService.deleteComment(slug, +id, user.sub);
-  }
 }

--- a/src/articles/articles.controller.ts
+++ b/src/articles/articles.controller.ts
@@ -4,6 +4,9 @@ import { AuthGuard } from '@nestjs/passport';
 import { CreateArticleDto, UpdateArticleDto } from './dto/article.dto';
 import { ArticleResponse, DeleteArticleResponse } from './interfaces/article.interface';
 import { Request } from 'express';
+import { CreateCommentDto } from './dto/comment.dto';
+import { CommentResponse, CommentsResponse } from './interfaces/comment.interface';
+import { GetUser } from './common/decorators/get-user.decorator';
 
 interface JwtPayload {
   sub: number;
@@ -58,5 +61,32 @@ export class ArticlesController {
       throw new UnauthorizedException('User not authenticated');
     }
     return this.articlesService.deleteArticle(slug, req.user.sub);
+  }
+
+  @Post(':slug/comments')
+  @UseGuards(AuthGuard('jwt'))
+  async createComment(
+    @Param('slug') slug: string,
+    @Body('comment') createCommentDto: CreateCommentDto,
+    @GetUser() user: JwtPayload,
+  ): Promise<CommentResponse> {
+    return this.articlesService.createComment(slug, user.sub, createCommentDto);
+  }
+
+  @Get(':slug/comments')
+  async getComments(
+    @Param('slug') slug: string,
+  ): Promise<CommentsResponse> {
+    return this.articlesService.getComments(slug);
+  }
+
+  @Delete(':slug/comments/:id')
+  @UseGuards(AuthGuard('jwt'))
+  async deleteComment(
+    @Param('slug') slug: string,
+    @Param('id') id: string,
+    @GetUser() user: JwtPayload,
+  ): Promise<void> {
+    return this.articlesService.deleteComment(slug, +id, user.sub);
   }
 }

--- a/src/articles/articles.module.ts
+++ b/src/articles/articles.module.ts
@@ -2,10 +2,11 @@ import { Module } from '@nestjs/common';
 import { ArticlesController } from './articles.controller';
 import { ArticlesService } from './articles.service';
 import { PrismaModule } from '../prisma/prisma.module';
+import { CommentsController } from './comments.controller';
 
 @Module({
   imports: [PrismaModule],
-  controllers: [ArticlesController],
+  controllers: [ArticlesController, CommentsController],
   providers: [ArticlesService]
 })
 export class ArticlesModule {}

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -194,7 +194,7 @@ export class ArticlesService {
     slug: string,
     commentId: number,
     userId: number,
-  ): Promise<void> {
+  ): Promise<{ message: string }> {
     const comment = await this.prisma.comment.findUnique({
       where: { id: commentId },
     });
@@ -210,5 +210,7 @@ export class ArticlesService {
     await this.prisma.comment.delete({
       where: { id: commentId },
     });
+
+    return { message: 'Comment deleted successfully' };
   }
 }

--- a/src/articles/articles.service.ts
+++ b/src/articles/articles.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateArticleDto, UpdateArticleDto } from './dto/article.dto';
+import { CreateCommentDto } from './dto/comment.dto';
 import { ArticleResponse, DeleteArticleResponse } from './interfaces/article.interface';
+import { CommentResponse, CommentsResponse } from './interfaces/comment.interface';
 
 @Injectable()
 export class ArticlesService {
@@ -109,5 +111,104 @@ export class ArticlesService {
     });
 
     return { message: 'Article deleted successfully' };
+  }
+
+  async createComment(
+    slug: string,
+    userId: number,
+    dto: CreateCommentDto,
+  ): Promise<CommentResponse> {
+    const article = await this.prisma.article.findUnique({
+      where: { slug },
+    });
+
+    if (!article) {
+      throw new NotFoundException('Article not found');
+    }
+
+    const comment = await this.prisma.comment.create({
+      data: {
+        body: dto.body,
+        article: { connect: { id: article.id } },
+        author: { connect: { id: userId } },
+      },
+      include: {
+        author: {
+          select: {
+            username: true,
+            bio: true,
+            image: true,
+          },
+        },
+      },
+    });
+
+    return {
+      comment: {
+        id: comment.id,
+        body: comment.body,
+        createdAt: comment.createdAt,
+        updatedAt: comment.updatedAt,
+        author: comment.author
+      }
+    };
+  }
+
+  async getComments(slug: string): Promise<CommentsResponse> {
+    const article = await this.prisma.article.findUnique({
+      where: { slug },
+    });
+
+    if (!article) {
+      throw new NotFoundException('Article not found');
+    }
+
+    const comments = await this.prisma.comment.findMany({
+      where: { articleId: article.id },
+      include: {
+        author: {
+          select: {
+            username: true,
+            bio: true,
+            image: true,
+          },
+        },
+      },
+      orderBy: [{
+        createdAt: 'desc'
+      }],
+    });
+
+    return {
+      comments: comments.map(comment => ({
+        id: comment.id,
+        body: comment.body,
+        createdAt: comment.createdAt,
+        updatedAt: comment.updatedAt,
+        author: comment.author
+      }))
+    };
+  }
+
+  async deleteComment(
+    slug: string,
+    commentId: number,
+    userId: number,
+  ): Promise<void> {
+    const comment = await this.prisma.comment.findUnique({
+      where: { id: commentId },
+    });
+
+    if (!comment) {
+      throw new NotFoundException('Comment not found');
+    }
+
+    if (comment.authorId !== userId) {
+      throw new UnauthorizedException('Not authorized to delete this comment');
+    }
+
+    await this.prisma.comment.delete({
+      where: { id: commentId },
+    });
   }
 }

--- a/src/articles/comments.controller.ts
+++ b/src/articles/comments.controller.ts
@@ -1,0 +1,43 @@
+import { Body, Controller, Delete, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { ArticlesService } from './articles.service';
+import { CreateCommentDto } from './dto/comment.dto';
+import { CommentResponse, CommentsResponse } from './interfaces/comment.interface';
+import { GetUser } from './common/decorators/get-user.decorator';
+
+interface JwtPayload {
+  sub: number;
+  email: string;
+}
+
+@Controller('api/articles/:slug/comments')
+export class CommentsController {
+  constructor(private readonly articlesService: ArticlesService) {}
+
+  @Post()
+  @UseGuards(AuthGuard('jwt'))
+  async createComment(
+    @Param('slug') slug: string,
+    @Body('comment') createCommentDto: CreateCommentDto,
+    @GetUser() user: JwtPayload,
+  ): Promise<CommentResponse> {
+    return this.articlesService.createComment(slug, user.sub, createCommentDto);
+  }
+
+  @Get()
+  async getComments(
+    @Param('slug') slug: string,
+  ): Promise<CommentsResponse> {
+    return this.articlesService.getComments(slug);
+  }
+
+  @Delete(':id')
+  @UseGuards(AuthGuard('jwt'))
+  async deleteComment(
+    @Param('slug') slug: string,
+    @Param('id') id: string,
+    @GetUser() user: JwtPayload,
+  ): Promise<{ message: string }> {
+    return this.articlesService.deleteComment(slug, +id, user.sub);
+  }
+}

--- a/src/articles/common/decorators/get-user.decorator.ts
+++ b/src/articles/common/decorators/get-user.decorator.ts
@@ -1,0 +1,16 @@
+import { createParamDecorator, ExecutionContext, UnauthorizedException } from '@nestjs/common';
+
+interface JwtPayload {
+  sub: number;
+  email: string;
+}
+
+export const GetUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext): JwtPayload => {
+    const request = ctx.switchToHttp().getRequest();
+    if (!request.user) {
+      throw new UnauthorizedException('User not authenticated');
+    }
+    return request.user;
+  },
+);

--- a/src/articles/dto/comment.dto.ts
+++ b/src/articles/dto/comment.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateCommentDto {
+  @IsString()
+  @IsNotEmpty()
+  body: string;
+}

--- a/src/articles/interfaces/comment.interface.ts
+++ b/src/articles/interfaces/comment.interface.ts
@@ -1,0 +1,19 @@
+export interface Comment {
+  id: number;
+  body: string;
+  createdAt: Date;
+  updatedAt: Date;
+  author: {
+    username: string;
+    bio: string | null;
+    image: string | null;
+  };
+}
+
+export interface CommentResponse {
+  comment: Comment;
+}
+
+export interface CommentsResponse {
+  comments: Comment[];
+}


### PR DESCRIPTION
1. Add Comment
Endpoint: POST /api/articles/:slug/comments

Authentication: Yêu cầu xác thực (user phải đăng nhập).

Mô tả:
API này cho phép người dùng đã đăng nhập thêm một bình luận mới vào bài viết được xác định bằng slug. Người dùng gửi nội dung bình luận trong phần thân của request. Sau khi bình luận được tạo thành công, API sẽ trả về thông tin chi tiết của bình luận bao gồm nội dung, thời gian tạo, và thông tin tác giả.

2. Get Comments
Endpoint: GET /api/articles/:slug/comments

Authentication: Không yêu cầu xác thực.

Mô tả:
API này trả về danh sách tất cả các bình luận của một bài viết, được xác định thông qua slug. Các bình luận sẽ được sắp xếp theo thời gian tạo mới nhất đến cũ nhất. Mỗi bình luận bao gồm nội dung, thời gian tạo, chỉnh sửa, và thông tin cơ bản của người viết bình luận (username, bio, avatar).

3. Delete Comment
Endpoint: DELETE /api/articles/:slug/comments/:id

Authentication: Yêu cầu xác thực (user phải đăng nhập).

Mô tả:
API này cho phép người dùng đã đăng nhập xóa một bình luận cụ thể dựa trên id của bình luận và slug của bài viết. Chỉ người đã tạo bình luận mới có quyền xóa. Nếu người dùng không phải là tác giả của bình luận hoặc bình luận không tồn tại, API sẽ trả về lỗi tương ứng (403 hoặc 404).